### PR TITLE
#FT-PS8 Pull docker imagers to host

### DIFF
--- a/handlers/httphandler/image.go
+++ b/handlers/httphandler/image.go
@@ -44,7 +44,7 @@ func setupImageHandler(db *driver.DB, client *client.Client, httpRouter *chi.Mux
 	router := chi.NewRouter()
 	router.Get("/list", handler.list)
 	router.Post("/pull", handler.pullImage)
-	setupRoute(httpRouter, router, "/image")
+	setupRoute(httpRouter, router, "/images")
 }
 
 // imageHandler ...

--- a/handlers/httphandler/image.go
+++ b/handlers/httphandler/image.go
@@ -102,12 +102,15 @@ func (image *imageHandler) pullImage(w http.ResponseWriter, r *http.Request) {
 	var remoteImage string
 	if len(imageData.Repository) == 0 {
 		remoteImage = fmt.Sprintf("%s/%s", Dockerhub, imageData.Name)
+	} else {
+		remoteImage = fmt.Sprintf("%s/%s", imageData.Repository, imageData.Name)
 	}
 
 	if len(imageData.Tag) > 0 {
 		remoteImage = fmt.Sprintf("%s:%s", remoteImage, imageData.Tag)
 	}
 
+	fmt.Println(remoteImage)
 	reader, err := image.dockerClient.ImagePull(r.Context(), remoteImage, types.ImagePullOptions{})
 	if err != nil {
 		errString := err.Error()

--- a/handlers/httphandler/routes.go
+++ b/handlers/httphandler/routes.go
@@ -16,11 +16,12 @@ func SetupRoutes(db *driver.DB) (*chi.Mux, error) {
 	router.Use(middleware.Logger)
 
 	client, err := client.NewEnvClient()
-
 	if err != nil {
 		fmt.Println(err)
 		return nil, err
 	}
+
 	setupImageHandler(db, client, router)
+
 	return router, nil
 }

--- a/main.go
+++ b/main.go
@@ -23,5 +23,9 @@ func main() {
 	}
 
 	fmt.Println("Portside server listening on port 8005")
-	http.ListenAndServe(":8005", router)
+	err = http.ListenAndServe(":8005", router)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 }

--- a/models/image.go
+++ b/models/image.go
@@ -2,6 +2,7 @@ package models
 
 // Image holds basic information about the docker image
 type Image struct {
+	Name       string   // Name of image
 	ID         string   //ID of the docker image
 	Size       int64    // Size of the docker image
 	Repository string   // Repository of the docker image


### PR DESCRIPTION
This PR creates an endpoint to pull docker images from a remote endpoint to the host. You can pull a docker image by sending a POST request to ```/images/pull``` with name, tag and repository parameters.

Example response:
```
{
    "Status": 200,
    "Data": {
        "Id": "sha256:1c35c441208254cb7c3844ba95a96485388cef9ccc0646d562c7fc026e04c807",
        "RepoTags": [
            "busybox:latest"
        ],
        "RepoDigests": [
            "busybox@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2020-06-02T21:19:57.279412246Z",
        "Container": "1c17e9df8a65c5e8e204d6a8b6131992cbbf53ccf8ded24b8b8f22efed98f2ff",
        "ContainerConfig": {
            "Hostname": "1c17e9df8a65",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [
                "/bin/sh",
                "-c",
                "#(nop) ",
                "CMD [\"sh\"]"
            ],
            "ArgsEscaped": true,
            "Image": "sha256:2aabc920ad7c34b4f1938797fd9c0b79e50820dffeeab14767ee742e441fb0b7",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": {}
        },
        "DockerVersion": "18.09.7",
        "Author": "",
        "Config": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [
                "sh"
            ],
            "ArgsEscaped": true,
            "Image": "sha256:2aabc920ad7c34b4f1938797fd9c0b79e50820dffeeab14767ee742e441fb0b7",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": null
        },
        "Architecture": "amd64",
        "Os": "linux",
        "Size": 1219430,
        "VirtualSize": 1219430,
        "GraphDriver": {
            "Name": "overlay2",
            "Data": {
                "MergedDir": "/var/lib/docker/overlay2/5e9ae4ab6f47c65cca893a56df52e624039c48344b708c90995e272fc77ae4e0/merged",
                "UpperDir": "/var/lib/docker/overlay2/5e9ae4ab6f47c65cca893a56df52e624039c48344b708c90995e272fc77ae4e0/diff",
                "WorkDir": "/var/lib/docker/overlay2/5e9ae4ab6f47c65cca893a56df52e624039c48344b708c90995e272fc77ae4e0/work"
            }
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:1be74353c3d0fd55fb5638a52953e6f1bc441e5b1710921db9ec2aa202725569"
            ]
        }
    }
}
```
<img width="1133" alt="Screenshot 2020-06-03 at 16 06 52" src="https://user-images.githubusercontent.com/17027969/83640050-45163100-a5b4-11ea-8355-811599f8dd5f.png">


closes #8 