### PR TITLE
FT-PS17: Return image labels with queried list of images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
-	github.com/dgraph-io/badger/v2 v2.0.3
+	github.com/dgraph-io/badger/v2 v2.0.3 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
@@ -13,5 +13,4 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/zippoxer/bow v0.0.0-20200229231453-bf1012ae7ab9
 	gopkg.in/dealancer/validate.v2 v2.1.0
-	gopkg.in/validator.v2 v2.0.0-20200605151824-2b28d334fa05
 )

--- a/models/image.go
+++ b/models/image.go
@@ -8,6 +8,7 @@ type Image struct {
 	Repository string   // Repository of the docker image
 	Tag        string   // Tag of the docker image
 	Digests    []string // List of sha256 digests
+	Labels     []string // List of image labels
 }
 
 // ImageLabel holds information needed to label an image

--- a/repository/image/badger_image.go
+++ b/repository/image/badger_image.go
@@ -23,20 +23,25 @@ type labelData struct {
 func (db *badgerDB) AddLabel(ctx context.Context, tag string, labels ...string) error {
 	label := models.ImageLabel{
 		Id:     tag,
-		Labels: labels,
+		Labels: make([]string, 0),
 	}
 
+	imageLabels, err := db.GetImageLabels(ctx, tag)
 	for _, labelName := range labels {
-		label := labelData{
+		newLabel := labelData{
 			Id: labelName,
 		}
-		err := db.Conn.Bucket("labels").Put(label)
+		err := db.Conn.Bucket("labels").Put(newLabel)
 		if err != nil {
 			return err
 		}
+		labelFound := Contains(imageLabels, labelName)
+		if labelFound == false {
+			label.Labels = append(label.Labels, labelName)
+		}
 	}
 
-	err := db.Conn.Bucket("labeledImages").Put(label)
+	err = db.Conn.Bucket("labeledImages").Put(label)
 	return err
 }
 

--- a/repository/image/badger_image.go
+++ b/repository/image/badger_image.go
@@ -40,8 +40,14 @@ func (db *badgerDB) AddLabel(ctx context.Context, tag string, labels ...string) 
 	return err
 }
 
-func (db *badgerDB) GetByName(ctx context.Context, name string) (*models.Image, error) {
-	return nil, nil
+// GetImageLabels Returns a list of labels associated with the image
+func (db *badgerDB) GetImageLabels(ctx context.Context, imageName string) (labels []string, err error) {
+	var imageLabel models.ImageLabel
+	err = db.Conn.Bucket("labeledImages").Get(imageName, &imageLabel)
+	if err != nil {
+		return nil, err
+	}
+	return imageLabel.Labels, nil
 }
 
 func (db *badgerDB) GetByLabel(ctx context.Context, label string) ([]*models.Image, error) {

--- a/repository/image/repository.go
+++ b/repository/image/repository.go
@@ -9,6 +9,6 @@ import (
 // ImageRepository runs queries for images against the database
 type ImageRepository interface {
 	AddLabel(ctx context.Context, label string, imageTags ...string) error
-	GetByName(ctx context.Context, name string) (*models.Image, error)
+	GetImageLabels(ctx context.Context, imageName string) (labels []string, err error)
 	GetByLabel(ctx context.Context, label string) ([]*models.Image, error)
 }


### PR DESCRIPTION
When a user queries the server for a list of container images, they list returned should also include a field named labels which contains an array of user-defined labels attached to each image.

closes #17 