### PR TITLE
FT-PS21: Filter image list by label

### DIFF
--- a/handlers/httphandler/image.go
+++ b/handlers/httphandler/image.go
@@ -184,5 +184,11 @@ func (image *imageHandler) labelImage(w http.ResponseWriter, r *http.Request) {
 		respondWithJSON(w, http.StatusInternalServerError, err)
 		return
 	}
-	respondWithJSON(w, http.StatusOK, labelInfo)
+
+	labels, err := image.repo.GetImageLabels(r.Context(), labelInfo.Image)
+	if err != nil {
+		respondWithJSON(w, http.StatusInternalServerError, err)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, labels)
 }

--- a/handlers/httphandler/image.go
+++ b/handlers/httphandler/image.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -62,44 +63,38 @@ type imageHandler struct {
 
 // list returns a list of all docker images on the host machine
 func (image *imageHandler) list(w http.ResponseWriter, r *http.Request) {
-	dockerImages, err := image.dockerClient.ImageList(r.Context(), types.ImageListOptions{})
-	if err != nil {
-		respondWithJSON(w, http.StatusInternalServerError, "Opps, Something went wrong")
-	}
-
-	var images []models.Image
-	if len(dockerImages) > 0 {
-		for _, imageData := range dockerImages {
-			var name string
-			var tag string
-			var dockerImageName string
-			if len(imageData.RepoTags) > 0 {
-				dockerImageName = imageData.RepoTags[0]
-				repoData := strings.Split(dockerImageName, ":")
-				name = repoData[0]
-				tag = repoData[1]
-			}
-
-			dockerImage := models.Image{
-				Name:       name,
-				ID:         imageData.ID,
-				Size:       imageData.Size,
-				Repository: "repo",
-				Tag:        tag,
-				Digests:    imageData.RepoDigests,
-				Labels:     make([]string, 0),
-			}
-
-			if len(dockerImageName) > 0 {
-				labels, err := image.repo.GetImageLabels(r.Context(), dockerImageName)
-				if err == nil {
-					dockerImage.Labels = labels
+	labels, ok := r.URL.Query()["withLabel"]
+	if ok && len(labels) > 0 {
+		var dockerImages []types.ImageInspect
+		for _, label := range labels {
+			labeledImages, err := image.repo.GetByLabel(r.Context(), label)
+			if err == nil && len(labeledImages) > 0 {
+				for _, labeledImage := range labeledImages {
+					dockerImage, _, err := image.dockerClient.ImageInspectWithRaw(r.Context(), labeledImage)
+					if err != nil {
+						continue
+					}
+					dockerImages = append(dockerImages, dockerImage)
 				}
 			}
-			images = append(images, dockerImage)
+		}
+		if len(dockerImages) > 0 {
+			image.marshallDockerImages(r.Context(), w, dockerImages)
+		} else {
+			respondWithJSON(w, http.StatusNotFound, "No images with matching labels found on the host system")
+		}
+	} else {
+		images, err := image.dockerClient.ImageList(r.Context(), types.ImageListOptions{})
+		if err != nil {
+			respondWithJSON(w, http.StatusInternalServerError, "Opps, Something went wrong")
+		}
+		if len(images) > 0 {
+			//dockerImages = append(dockerImages, images)
+			image.marshallDockerImages(r.Context(), w, images)
+		} else {
+			respondWithJSON(w, http.StatusNotFound, "No images found on the host system")
 		}
 	}
-	respondWithJSON(w, http.StatusOK, images)
 }
 
 // GetByName ...
@@ -191,4 +186,44 @@ func (image *imageHandler) labelImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	respondWithJSON(w, http.StatusOK, labels)
+}
+
+func (image *imageHandler) marshallDockerImages(ctx context.Context, w http.ResponseWriter, dockerImages interface{}) {
+	var images []models.Image
+	dockerImagesVal := reflect.ValueOf(dockerImages)
+	for i := 0; i < dockerImagesVal.Len(); i++ {
+		var name string
+		var tag string
+		imageData := dockerImagesVal.Index(i)
+		var dockerImageName string
+		repoTags := imageData.FieldByName("RepoTags").Interface().([]string)
+		if len(repoTags) > 0 {
+			dockerImageName = repoTags[0]
+			repoData := strings.Split(dockerImageName, ":")
+			name = repoData[0]
+			tag = repoData[1]
+		}
+
+		imageID := imageData.FieldByName("ID").String()
+		imageSize := imageData.FieldByName("Size").Int()
+		repoDigests := imageData.FieldByName("RepoDigests").Interface().([]string)
+		dockerImage := models.Image{
+			Name:       name,
+			ID:         imageID,
+			Size:       imageSize,
+			Repository: "repo",
+			Tag:        tag,
+			Digests:    repoDigests,
+			Labels:     make([]string, 0),
+		}
+
+		if len(dockerImageName) > 0 {
+			labels, err := image.repo.GetImageLabels(ctx, dockerImageName)
+			if err == nil {
+				dockerImage.Labels = labels
+			}
+		}
+		images = append(images, dockerImage)
+	}
+	respondWithJSON(w, http.StatusOK, images)
 }

--- a/repository/image/badger_image.go
+++ b/repository/image/badger_image.go
@@ -38,7 +38,7 @@ func (db *badgerDB) AddLabel(ctx context.Context, tag string, labels ...string) 
 		}
 
 		imageFound := ArrayContains(newLabel.Images, tag)
-		if imageFound == false {
+		if !imageFound {
 			newLabel.Images = append(newLabel.Images, tag)
 			err := db.Conn.Bucket("labels").Put(newLabel)
 			if err != nil {
@@ -47,7 +47,7 @@ func (db *badgerDB) AddLabel(ctx context.Context, tag string, labels ...string) 
 		}
 
 		labelFound := ArrayContains(imageLabels, labelName)
-		if labelFound == false {
+		if !labelFound {
 			label.Labels = append(label.Labels, labelName)
 		}
 	}
@@ -65,6 +65,8 @@ func (db *badgerDB) GetImageLabels(ctx context.Context, imageName string) (label
 	return imageLabel.Labels, nil
 }
 
-func (db *badgerDB) GetByLabel(ctx context.Context, label string) ([]*models.Image, error) {
-	return nil, nil
+func (db *badgerDB) GetByLabel(ctx context.Context, label string) ([]string, error) {
+	var imageLabel labelData
+	err := db.Conn.Bucket("labels").Get(label, &imageLabel)
+	return imageLabel.Images, err
 }

--- a/repository/image/common.go
+++ b/repository/image/common.go
@@ -1,0 +1,11 @@
+package repository
+
+// ArrayContains finds if an element (pin) is inside an array (hayStack)
+func ArrayContains(hayStack []string, pin string) bool {
+	for _, val := range hayStack {
+		if val == pin {
+			return true
+		}
+	}
+	return false
+}

--- a/repository/image/repository.go
+++ b/repository/image/repository.go
@@ -2,13 +2,11 @@ package repository
 
 import (
 	"context"
-
-	"github.com/geekakili/portside/models"
 )
 
 // ImageRepository runs queries for images against the database
 type ImageRepository interface {
 	AddLabel(ctx context.Context, label string, imageTags ...string) error
 	GetImageLabels(ctx context.Context, imageName string) (labels []string, err error)
-	GetByLabel(ctx context.Context, label string) ([]*models.Image, error)
+	GetByLabel(ctx context.Context, label string) ([]string, error)
 }


### PR DESCRIPTION
A user should be able to filter the list of images by labels. The labels to be used for filtering the list are passed as URL query parameters. The URL query param responsible for filtering is `withLabel`

Below is an example of an endpoint for filtering an image by a certain label;
`http://localhost:8005/images/list?withLabel=dbj`

To filter the query using multiple labels, you can use URL params constructed like below
`http://localhost:8005/images/list?withLabel=dbj&withLabel=database`

closes #21 