### PR TITLE
FT-PS19:Return a list of labels on the host

### DIFF
--- a/handlers/httphandler/label.go
+++ b/handlers/httphandler/label.go
@@ -20,7 +20,8 @@ func setupLabelHandler(db *driver.DB, client *client.Client, httpRouter *chi.Mux
 
 	router := chi.NewRouter()
 	router.Post("/add", handler.add)
-	// router.Post("/list", handler.list)
+	router.Get("/list/{label}", handler.list)
+	router.Get("/list", handler.list)
 	// router.Post("/edit", handler.edit)
 	// router.Post("/delete", handler.delete)
 	setupRoute(httpRouter, router, "/labels")
@@ -53,17 +54,22 @@ func (label *labelHandler) add(w http.ResponseWriter, r *http.Request) {
 	respondWithJSON(w, http.StatusOK, newlabel)
 }
 
-// // GetByName ...
-// func (label *labelHandler) list(w http.ResponseWriter, r *http.Request) {
-
-// }
-
-// // GetByLabel ...
-// func (label *labelHandler) edit(w http.ResponseWriter, r *http.Request) {
-
-// }
-
-// // PullImage pulls image from remote repository
-// func (label *labelHandler) delete(w http.ResponseWriter, r *http.Request) {
-
-// }
+// list ...
+func (label *labelHandler) list(w http.ResponseWriter, r *http.Request) {
+	labelName := chi.URLParam(r, "label")
+	if len(labelName) > 0 {
+		labelData, err := label.repo.GetLabel(r.Context(), labelName)
+		if err != nil {
+			respondWithJSON(w, http.StatusNotFound, "Label with such a name not found")
+			return
+		}
+		respondWithJSON(w, http.StatusOK, labelData)
+	} else {
+		labels := label.repo.GetLabels(r.Context())
+		if len(labels) > 0 {
+			respondWithJSON(w, http.StatusOK, labels)
+			return
+		}
+		respondWithJSON(w, http.StatusNotFound, "No labels exist on this host")
+	}
+}

--- a/models/image.go
+++ b/models/image.go
@@ -13,6 +13,6 @@ type Image struct {
 
 // ImageLabel holds information needed to label an image
 type ImageLabel struct {
-	Id     string `bow:"key"`
+	Image  string `bow:"key"`
 	Labels []string
 }

--- a/repository/image/badger_image.go
+++ b/repository/image/badger_image.go
@@ -17,24 +17,19 @@ type badgerDB struct {
 	Conn *bow.DB
 }
 
-type labelData struct {
-	Id     string `bow:"key"`
-	Images []string
-}
-
 func (db *badgerDB) AddLabel(ctx context.Context, tag string, labels ...string) error {
 	imageLabels, _ := db.GetImageLabels(ctx, tag)
 	label := models.ImageLabel{
-		Id:     tag,
+		Image:  tag,
 		Labels: imageLabels,
 	}
 
 	for _, labelName := range labels {
-		var newLabel labelData
+		var newLabel models.Label
 		err := db.Conn.Bucket("labels").Get(labelName, &newLabel)
 		if err != nil {
-			newLabel = labelData{
-				Id: labelName,
+			newLabel = models.Label{
+				Name: labelName,
 			}
 		}
 
@@ -67,7 +62,7 @@ func (db *badgerDB) GetImageLabels(ctx context.Context, imageName string) (label
 }
 
 func (db *badgerDB) GetByLabel(ctx context.Context, label string) ([]string, error) {
-	var imageLabel labelData
+	var imageLabel models.Label
 	err := db.Conn.Bucket("labels").Get(label, &imageLabel)
 	return imageLabel.Images, err
 }

--- a/repository/label/badger_label.go
+++ b/repository/label/badger_label.go
@@ -31,3 +31,20 @@ func (db *badgerDB) AddLabel(ctx context.Context, label string, description stri
 
 	return labelData, nil
 }
+
+func (db *badgerDB) GetLabel(ctx context.Context, label string) (models.Label, error) {
+	labelData := new(models.Label)
+	err := db.Conn.Bucket("labels").Get(label, labelData)
+	return *labelData, err
+}
+
+func (db *badgerDB) GetLabels(ctx context.Context) []models.Label {
+	labelData := new(models.Label)
+	var labels []models.Label
+	iter := db.Conn.Bucket("labels").Iter()
+	defer iter.Close()
+	for iter.Next(labelData) {
+		labels = append(labels, *labelData)
+	}
+	return labels
+}

--- a/repository/label/label_repository.go
+++ b/repository/label/label_repository.go
@@ -9,8 +9,8 @@ import (
 // LabelRepository ..
 type LabelRepository interface {
 	AddLabel(ctx context.Context, label string, description string) (*models.Label, error)
-	// GetLabel(ctx context.Context, label string) (models.Label, error)
-	// GetLabels(ctx context.Context) ([]models.Label, error)
+	GetLabel(ctx context.Context, label string) (models.Label, error)
+	GetLabels(ctx context.Context) []models.Label
 	// EditLabel(ctx context.Context, label string, newName string, newDescription string) (models.Label, error)
 	// Delete(ctx context.Context, label string) bool
 }


### PR DESCRIPTION
This PR creates an endpoint to allow a user to return a list of labels on the host. The two endpoints required for this operation are;

1. `http://localhost:8005/labels/list/{labelName}` for example `http://localhost:8005/labels/list/databases`: This can be used to return information about the individual label. It returns a JSON body in this formart;
```
{
    "Status": 200,
    "Message": {
        "Name": "databases",
        "Description": "Database labels",
        "Images": ["image1","image2"]
    }
}
```

2.  `http://localhost:8005/labels/list`: This returns a list of all labels created on the host for example;
```
{
    "Status": 200,
    "Message": [
        {
            "Name": "database_sql",
            "Description": "SQL Database",
            "Images": ["mysql:latest","postgres:latest"]
        },
        {
            "Name": "database_KV",
            "Description": "Database labels",
            "Images": ["etcd"]
        }
  ]
}
```

closes #19 