### PR TITLE
FT-PS20:Delete label from db

### DIFF
--- a/handlers/httphandler/label.go
+++ b/handlers/httphandler/label.go
@@ -23,7 +23,7 @@ func setupLabelHandler(db *driver.DB, client *client.Client, httpRouter *chi.Mux
 	router.Get("/list/{label}", handler.list)
 	router.Get("/list", handler.list)
 	// router.Post("/edit", handler.edit)
-	// router.Post("/delete", handler.delete)
+	router.Delete("/delete/{label}", handler.delete)
 	setupRoute(httpRouter, router, "/labels")
 }
 
@@ -72,4 +72,18 @@ func (label *labelHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 		respondWithJSON(w, http.StatusNotFound, "No labels exist on this host")
 	}
+}
+
+func (label *labelHandler) delete(w http.ResponseWriter, r *http.Request) {
+	labelName := chi.URLParam(r, "label")
+	if len(labelName) > 0 {
+		deleted, err := label.repo.Delete(r.Context(), labelName)
+		if err != nil || !deleted {
+			respondWithJSON(w, http.StatusInternalServerError, "Label failed to delete")
+			return
+		}
+		respondWithJSON(w, http.StatusOK, "Label deleted successfully")
+		return
+	}
+	respondWithJSON(w, http.StatusBadRequest, "Could not delete label, request is malformed")
 }

--- a/repository/label/badger_label.go
+++ b/repository/label/badger_label.go
@@ -16,6 +16,7 @@ type badgerDB struct {
 	Conn *bow.DB
 }
 
+// Addlabel adds a label to the database
 func (db *badgerDB) AddLabel(ctx context.Context, label string, description string) (*models.Label, error) {
 	labelData := new(models.Label)
 	err := db.Conn.Bucket("labels").Get(label, labelData)
@@ -32,12 +33,14 @@ func (db *badgerDB) AddLabel(ctx context.Context, label string, description stri
 	return labelData, nil
 }
 
+// GetLabel returns a label from the database
 func (db *badgerDB) GetLabel(ctx context.Context, label string) (models.Label, error) {
 	labelData := new(models.Label)
 	err := db.Conn.Bucket("labels").Get(label, labelData)
 	return *labelData, err
 }
 
+// GetLabels returns labels from the database
 func (db *badgerDB) GetLabels(ctx context.Context) []models.Label {
 	labelData := new(models.Label)
 	var labels []models.Label
@@ -47,4 +50,17 @@ func (db *badgerDB) GetLabels(ctx context.Context) []models.Label {
 		labels = append(labels, *labelData)
 	}
 	return labels
+}
+
+// Delete deletes a label from the database
+func (db *badgerDB) Delete(ctx context.Context, label string) (bool, error) {
+	labelData, err := db.GetLabel(ctx, label)
+	if err == nil {
+		err := db.Conn.Bucket("labels").Delete(labelData.Name)
+		if err != nil {
+			return false, err
+		}
+		return true, err
+	}
+	return false, err
 }

--- a/repository/label/label_repository.go
+++ b/repository/label/label_repository.go
@@ -12,5 +12,5 @@ type LabelRepository interface {
 	GetLabel(ctx context.Context, label string) (models.Label, error)
 	GetLabels(ctx context.Context) []models.Label
 	// EditLabel(ctx context.Context, label string, newName string, newDescription string) (models.Label, error)
-	// Delete(ctx context.Context, label string) bool
+	Delete(ctx context.Context, label string) (bool, error)
 }


### PR DESCRIPTION
This pull request provides an API endpoint to delete an image label. To delete an image label, send a DELETE request to `http://localhost:8005/labels/delete/{labelName}` replacing the labelName with the actual label you want to delete. 

On a successful request, a user will get a json response like;
```
{
    "Status": 200,
    "Message": "Label deleted successfully"
}
```

closes #20 