### PR TITLE
FT-PS26: Edit Labels

### DIFF
--- a/repository/label/badger_label.go
+++ b/repository/label/badger_label.go
@@ -52,6 +52,24 @@ func (db *badgerDB) GetLabels(ctx context.Context) []models.Label {
 	return labels
 }
 
+// GetLabels returns labels from the database
+func (db *badgerDB) Updatelabel(ctx context.Context, label string, labelData models.Label) error {
+	oldLabel, err := db.GetLabel(ctx, label)
+	if err == nil && &oldLabel != nil {
+		if len(labelData.Name) > 0 {
+			oldLabel.Name = labelData.Name
+		}
+
+		if len(labelData.Description) > 0 {
+			oldLabel.Description = labelData.Description
+		}
+
+		err = db.Conn.Bucket("labels").Put(oldLabel)
+		return err
+	}
+	return nil
+}
+
 // Delete deletes a label from the database
 func (db *badgerDB) Delete(ctx context.Context, label string) (bool, error) {
 	labelData, err := db.GetLabel(ctx, label)

--- a/repository/label/label_repository.go
+++ b/repository/label/label_repository.go
@@ -11,6 +11,6 @@ type LabelRepository interface {
 	AddLabel(ctx context.Context, label string, description string) (*models.Label, error)
 	GetLabel(ctx context.Context, label string) (models.Label, error)
 	GetLabels(ctx context.Context) []models.Label
-	// EditLabel(ctx context.Context, label string, newName string, newDescription string) (models.Label, error)
+	Updatelabel(ctx context.Context, label string, labelData models.Label) error
 	Delete(ctx context.Context, label string) (bool, error)
 }


### PR DESCRIPTION
This PR provides an API endpoint to edit a label.
Endpoint: `http://localhost:8005/labels/update/{labelName}` ie. `http://localhost:8005/labels/update/db`.
Body: The fields in the body are optional but for the request to succeed, one of them has to be present.
```
{
	"name": "databases",
	"description": "Databases"
}
```

closes #26 
